### PR TITLE
Prevent Numeric keys to be lost during merge

### DIFF
--- a/libraries/cimongo/Cimongo.php
+++ b/libraries/cimongo/Cimongo.php
@@ -402,7 +402,7 @@ class Cimongo extends Cimongo_extras{
 		}
 		if (is_array($data) && count($data) > 0){
 			$this->_update_init('$set');
-			$this->updates['$set'] = array_merge($this->updates['$set'], $data);
+			$this->updates['$set'] += $data;
 		}
 		if (count($this->updates) == 0){
 			show_error("Nothing to update in Mongo collection or update is not an array", 500);


### PR DESCRIPTION
prevent this effect: 
http://www.vancelucas.com/blog/php-array_merge-preserving-numeric-keys/
