### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Available Functions
 	Author
 ------------------- 
 
-####Alessandro Arnodo
+#### Alessandro Arnodo
 
 +	[@vesparny](https://twitter.com/vesparny)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
